### PR TITLE
Remove -isig flag to restore control keys issue #3

### DIFF
--- a/lib/Term/Screen.pm
+++ b/lib/Term/Screen.pm
@@ -113,7 +113,7 @@ sub new
 sub DESTROY
 {
     my $rc = $?;
-    system('stty -raw -isig echo 2>/dev/null'); 
+    system('stty -raw echo 2>/dev/null'); 
     $? = $rc;
 }
 


### PR DESCRIPTION
Re: issue #3. Remove -isig flag in DESTROY sub routine to restore control characters in terminal after program exits.